### PR TITLE
Document that `SslStream` has been obsoleted

### DIFF
--- a/conceptual/Npgsql/release-notes/4.1.md
+++ b/conceptual/Npgsql/release-notes/4.1.md
@@ -23,3 +23,4 @@ Many other small improvements and performance optimizations have been introduced
 
 * .NET 4.5, .NET 4.5.1 and .NET 4.5.2 are no longer supported. .NET 4.6.1 and .NET Standard 2.0 are the lowest supported versions. 
 * The spatial plugin, Npgsql.NetTopologySuite, has been updated to depend on NetTopologySuite 2.0.0, which is a major version introducing breaking changes. Specifically, EF Core 3.0 is the first version supporting NetTopologySuite 2.0.0; it is not possible to use EF Core 2.x with the new version of Npgsql.NetTopologySuite.
+* The `UseSslStream` property of `NpgsqlConnectionStringBuilder` is now marked as `Obselete`. `SslStream` is always used.


### PR DESCRIPTION
I'm not sure if you want this as a breaking change, as it is only breaking for people that compile with warn as error. But most sensible people do :)