### PR TITLE
Move installation information out to a new page

### DIFF
--- a/conceptual/Npgsql/index.md
+++ b/conceptual/Npgsql/index.md
@@ -39,34 +39,3 @@ using (var conn = new NpgsqlConnection(connString))
 
 You can find more info about the ADO.NET API in the [MSDN docs](https://msdn.microsoft.com/en-us/library/h43ks021(v=vs.110).aspx)
 or in many tutorials on the Internet.
-
-## DbProviderFactory
-
-The example above involves some Npgsql-specific types (`NpgsqlConnection`, `NpgsqlCommand`...), which makes your application Npgsql-specific. If your code needs to be database-portable, you should use the ADO.NET `DbProviderFactory` API instead ([see this tutorial](https://msdn.microsoft.com/en-us/library/dd0w4a2z%28v=vs.110%29.aspx?f=255&MSPPError=-21472173960)). In a nutshell, you register Npgsql's provider factory in your application's `App.config` (or `machines.config`) file, and then obtain it in your code without referencing any Npgsql-specific types. You can then use the factory to create a `DbConnection` (which `NpgsqlConnection` extends), and from there a `DbCommand` and so on.
-
-To do this, add the following to your `App.config`:
-
-```xml
-<system.data>
-  <DbProviderFactories>
-    <add name="Npgsql Data Provider" invariant="Npgsql" description=".Net Data Provider for PostgreSQL" type="Npgsql.NpgsqlFactory, Npgsql, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7"/>
-  </DbProviderFactories>
-</system.data>
-```
-
-## GAC Installation
-
-In some cases you'll want to install Npgsql into your [Global Assembly Cache (GAC)](https://msdn.microsoft.com/en-us/library/yf1d93sz%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396). This is usually the case when you're using a generic database program that can work with any ADO.NET provider but doesn't come with Npgsql or reference it directly. For these cases, you can download the Npgsql Windows installer from [our Github releases page](https://github.com/npgsql/npgsql/releases): it will install Npgsql (and optionally the Entity Framework providers) into your GAC and add Npgsql's DbProviderFactory into your `machine.config` file.  This is *not* the general recommended method of using Npgsql - always install via Nuget if possible. In addition to Npgsql.dll, this will also install `System.Threading.Tasks.Extensions.dll` into the GAC.
-
-## Visual Studio Integration
-
-If you'd like to have Visual Studio Design-Time support, give our [VSIX extension a try](ddex.md).
-
-## Unstable Packages
-
-The Npgsql build server publishes CI nuget packages for every build. If a bug affecting you was fixed but there hasn't yet been a patch release,
-you can get a CI nuget at our [stable MyGet feed](https://www.myget.org/gallery/npgsql). These packages are generally stable and
-safe to use (although it's better to wait for a release).
-
-We also publish CI packages for the next minor/major version at our [unstable MyGet feed](https://www.myget.org/gallery/npgsql-unstable).
-These are definitely unstable and should be used with care.

--- a/conceptual/Npgsql/installation.md
+++ b/conceptual/Npgsql/installation.md
@@ -1,0 +1,35 @@
+---
+layout: doc
+title: Installation
+---
+
+## Offical Packages
+
+Official releases of Npgsql are always available on [nuget.org](https://www.nuget.org/packages/Npgsql/). This is the recommended way to use Npgsql.
+
+## Unstable Packages
+
+In additional to the official releases, we automatically publish CI packages for every build. You can use these to test new features or bug fixes that haven't been released yet. Two CI nuget feeds are available:
+
+* [The patch feed](https://www.myget.org/gallery/npgsql)] contains CI packages for the next hotfix/patch version. These packages are generally very stable and safe.
+* [The vNext feed](https://www.myget.org/gallery/npgsql-unstable) contains CI packages for the next minor or major versions. These are less stable and should be tested with care.
+
+## Visual Studio Integration
+
+If you'd like to have Visual Studio Design-Time support, give our [VSIX extension a try](ddex.md).
+
+## GAC Installation
+
+In some cases you'll want to install Npgsql into your [Global Assembly Cache (GAC)](https://msdn.microsoft.com/en-us/library/yf1d93sz%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396). This is usually the case when you're using a generic .NET Framework program that can work with any ADO.NET provider but doesn't come with Npgsql or reference it directly (e.g. Excel, PowerBI...). For these cases, you can download the Npgsql Windows installer from [our Github releases page](https://github.com/npgsql/npgsql/releases): it will install Npgsql (and optionally the Entity Framework providers) into your GAC and add Npgsql's DbProviderFactory into your `machine.config` file.  This is *not* the general recommended method of using Npgsql - always install via Nuget if possible. In addition to Npgsql.dll, this will also install `System.Threading.Tasks.Extensions.dll` into the GAC.
+
+## DbProviderFactory in .NET Framework
+
+On .NET Framework, you can register Npgsql's `DbProviderFactory` in your applications `App.Config` (or `Web.Config`), allowing you to use general, provider-independent ADO.NET types in your application (e.g. `DbConnection` instead of `NpgsqlConnection`) - [see this tutorial](https://msdn.microsoft.com/en-us/library/dd0w4a2z%28v=vs.110%29.aspx?f=255&MSPPError=-21472173960). To do this, add the following to your `App.config`:
+
+```xml
+<system.data>
+  <DbProviderFactories>
+    <add name="Npgsql Data Provider" invariant="Npgsql" description=".Net Data Provider for PostgreSQL" type="Npgsql.NpgsqlFactory, Npgsql, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7"/>
+  </DbProviderFactories>
+</system.data>
+```

--- a/conceptual/Npgsql/toc.md
+++ b/conceptual/Npgsql/toc.md
@@ -5,8 +5,8 @@
 ## [3.2](release-notes/3.2.md)
 ## [3.1](release-notes/3.1.md)
 ## [3.0](release-notes/3.0.md)
-# [FAQ](faq.md)
 # [Compatibility Notes](compatibility.md)
+# [Installation](installation.md)
 # [Basic Usage](basic-usage.md)
 # [Connection String Parameters](connection-string-parameters.md)
 # [Security and Encryption](security.md)
@@ -28,6 +28,7 @@
 # [Bulk Copy](copy.md)
 # [Logging](logging.md)
 # [Visual Studio Integration](ddex.md)
+# [FAQ](faq.md)
 # [API Reference](../../obj/api/Npgsql/)
 # Developer Notes
 ## [Tests](dev/tests.md)


### PR DESCRIPTION
Because our very first index page shouldn't contain stuff like GAC installation and App.Config...