### PR TITLE
Updated DataType names for time and timestamp to have 'without time z…

### DIFF
--- a/conceptual/Npgsql/types/basic.md
+++ b/conceptual/Npgsql/types/basic.md
@@ -11,59 +11,59 @@ The following shows the mappings used when reading values.
 * You can read as other types by calling `NpgsqlDataReader.GetFieldValue<T>()`.
 * Provider-specific types are returne by `NpgsqlDataReader.GetProviderSpecificValue()`.
 
-PostgreSQL type          | Default .NET type          | Provider-specific type | Other .NET types
--------------------------|----------------------------|------------------------|-----------------
-boolean                  | bool                       |                        |
-smallint                 | short                      |                        | byte, sbyte, int, long, float, double, decimal
-integer                  | int                        |                        | byte, short, long, float, double, decimal
-bigint                   | long                       |                        | long, byte, short, int, float, double, decimal
-real                     | float                      |                        | double
-double precision         | double                     |                        |
-numeric                  | decimal                    |                        | byte, short, int, long, float, double
-money                    | decimal                    |                        |
-text                     | string                     |                        | char[]
-character varying        | string                     |                        | char[]
-character                | string                     |                        | char[]
-citext                   | string                     |                        | char[]
-json                     | string                     |                        | char[]
-jsonb                    | string                     |                        | char[]
-xml                      | string                     |                        | char[]
-point                    | NpgsqlPoint                |                        |
-lseg                     | NpgsqlLSeg                 |                        |
-path                     | NpgsqlPath                 |                        |
-polygon                  | NpgsqlPolygon              |                        |
-line                     | NpgsqlLine                 |                        |
-circle                   | NpgsqlCircle               |                        |
-box                      | NpgsqlBox                  |                        |
-bit(1)                   | bool                       |                        | BitArray
-bit(n)                   | BitArray                   |                        |
-bit varying              | BitArray                   |                        |
-hstore                   | Dictionary<string, string> |                        |
-uuid                     | Guid                       |                        |
-cidr                     | (IPAddress, int)           |                        | NpgsqlInet
-inet                     | IPAddress                  | (IPAddress, int)       | NpgsqlInet
-macaddr                  | PhysicalAddress            |                        |
-tsquery                  | NpgsqlTsQuery              |                        |
-tsvector                 | NpgsqlTsVector             |                        |
-date                     | DateTime                   | NpgsqlDate             |
-interval                 | TimeSpan                   | NpgsqlTimeSpan         |
-timestamp                | DateTime (Unspecified)     | NpgsqlDateTime         |
-timestamp with time zone | DateTime (Local)           | NpgsqlDateTime         | DateTimeOffset
-time                     | TimeSpan                   |                        |
-time with time zone      | DateTimeOffset             |                        | DateTimeOffset, DateTime, TimeSpan
-bytea                    | byte[]                     |                        |
-oid                      | uint                       |                        |
-xid                      | uint                       |                        |
-cid                      | uint                       |                        |
-oidvector                | uint[]                     |                        |
-name                     | string                     |                        | char[]
-(internal) char          | char                       |                        | byte, short, int, long
-geometry (PostGIS)       | PostgisGeometry            |                        |
-record                   | object[]                   |                        |
-composite types          | T                          |                        |
-range subtypes           | NpgsqlRange\<TElement>     |                        |
-enum types               | TEnum                      |                        |
-array types              | Array (of element type)    |                        |
+PostgreSQL type             | Default .NET type          | Provider-specific type | Other .NET types
+----------------------------|----------------------------|------------------------|-----------------
+boolean                     | bool                       |                        |
+smallint                    | short                      |                        | byte, sbyte, int, long, float, double, decimal
+integer                     | int                        |                        | byte, short, long, float, double, decimal
+bigint                      | long                       |                        | long, byte, short, int, float, double, decimal
+real                        | float                      |                        | double
+double precision            | double                     |                        |
+numeric                     | decimal                    |                        | byte, short, int, long, float, double
+money                       | decimal                    |                        |
+text                        | string                     |                        | char[]
+character varying           | string                     |                        | char[]
+character                   | string                     |                        | char[]
+citext                      | string                     |                        | char[]
+json                        | string                     |                        | char[]
+jsonb                       | string                     |                        | char[]
+xml                         | string                     |                        | char[]
+point                       | NpgsqlPoint                |                        |
+lseg                        | NpgsqlLSeg                 |                        |
+path                        | NpgsqlPath                 |                        |
+polygon                     | NpgsqlPolygon              |                        |
+line                        | NpgsqlLine                 |                        |
+circle                      | NpgsqlCircle               |                        |
+box                         | NpgsqlBox                  |                        |
+bit(1)                      | bool                       |                        | BitArray
+bit(n)                      | BitArray                   |                        |
+bit varying                 | BitArray                   |                        |
+hstore                      | Dictionary<string, string> |                        |
+uuid                        | Guid                       |                        |
+cidr                        | (IPAddress, int)           |                        | NpgsqlInet
+inet                        | IPAddress                  | (IPAddress, int)       | NpgsqlInet
+macaddr                     | PhysicalAddress            |                        |
+tsquery                     | NpgsqlTsQuery              |                        |
+tsvector                    | NpgsqlTsVector             |                        |
+date                        | DateTime                   | NpgsqlDate             |
+interval                    | TimeSpan                   | NpgsqlTimeSpan         |
+timestamp without time zone | DateTime (Unspecified)     | NpgsqlDateTime         |
+timestamp with time zone    | DateTime (Local)           | NpgsqlDateTime         | DateTimeOffset
+time without time zone      | TimeSpan                   |                        |
+time with time zone         | DateTimeOffset             |                        | DateTimeOffset, DateTime, TimeSpan
+bytea                       | byte[]                     |                        |
+oid                         | uint                       |                        |
+xid                         | uint                       |                        |
+cid                         | uint                       |                        |
+oidvector                   | uint[]                     |                        |
+name                        | string                     |                        | char[]
+(internal) char             | char                       |                        | byte, short, int, long
+geometry (PostGIS)          | PostgisGeometry            |                        |
+record                      | object[]                   |                        |
+composite types             | T                          |                        |
+range subtypes              | NpgsqlRange\<TElement>     |                        |
+enum types                  | TEnum                      |                        |
+array types                 | Array (of element type)    |                        |
 
 The Default .NET type column specifies the data type `NpgsqlDataReader.GetValue()` will return.
 
@@ -82,56 +82,56 @@ There are three rules that determine the PostgreSQL type sent for a parameter:
 
 Note that for `DateTime` and `NpgsqlDateTime`, the `Kind` attribute determines whether to use `timestamp` or `timestamptz`.
 
-NpgsqlDbType                  | DbType              | PostgreSQL type          | Accepted .NET types
-------------------------------|---------------------|--------------------------|--------------------
-Boolean                       | Boolean             | boolean                  | bool
-Smallint                      | Int16               | smallint                 | short
-Integer                       | Int32               | integer                  | int
-Bigint                        | Int64               | bigint                   | long
-Real                          | Single              | real                     | float
-Double                        | Double              | double precision         | double
-Numeric                       | Decimal, VarNumeric | numeric                  | decimal
-Money                         | Currency            | money                    | decimal
+NpgsqlDbType                  | DbType              | PostgreSQL type             | Accepted .NET types
+------------------------------|---------------------|-----------------------------|--------------------
+Boolean                       | Boolean             | boolean                     | bool
+Smallint                      | Int16               | smallint                    | short
+Integer                       | Int32               | integer                     | int
+Bigint                        | Int64               | bigint                      | long
+Real                          | Single              | real                        | float
+Double                        | Double              | double precision            | double
+Numeric                       | Decimal, VarNumeric | numeric                     | decimal
+Money                         | Currency            | money                       | decimal
 Text                          | String, StringFixedLength, AnsiString, AnsiStringFixedLength | text | string, char[], char
-Varchar                       |                     | character varying        | string, char[], char
-Char                          |                     | character                | string, char[], char
-Citext                        |                     | citext                   | string, char[], char
-Json                          |                     | json                     | string, char[], char
-Jsonb                         |                     | jsonb                    | string, char[], char
-Xml                           |                     | xml                      | string, char[], char
-Point                         |                     | point                    | NpgsqlPoint
-LSeg                          |                     | lseg                     | NpgsqlLSeg
-Path                          |                     | path                     | NpgsqlPath
-Polygon                       |                     | polygon                  | NpgsqlPolygon
-Line                          |                     | line                     | NpgsqlLine
-Circle                        |                     | circle                   | NpgsqlCircle
-Box                           |                     | box                      | NpgsqlBox
-Bit                           |                     | bit                      | BitArray, bool, string
-Varbit                        |                     | bit varying              | BitArray, bool, string
-Hstore                        |                     | hstore                   | IDictionary<string, string>
-Uuid                          |                     | uuid                     | Guid
-Cidr                          |                     | cidr                     | ValueTuple<IPAddress, int>, IPAddress, NpgsqlInet
-Inet                          |                     | inet                     | ValueTuple<IPAddress, int>, IPAddress, NpgsqlInet
-MacAddr                       |                     | macaddr                  | PhysicalAddress
-TsQuery                       |                     | tsquery                  | NpgsqlTsQuery
-TsVector                      |                     | tsvector                 | NpgsqlTsVector
-Date                          | Date                | date                     | DateTime, NpgsqlDate
-Interval                      |                     | interval                 | TimeSpan, NpgsqlTimeSpan
-Timestamp                     | DateTime, DateTime2 | timestamp                | DateTime, NpgsqlDateTime
-TimestampTz                   | DateTimeOffset      | timestamp with time zone | DateTime, DateTimeOffset, NpgsqlDateTime
-Time                          | Time                | time                     | TimeSpan
-TimeTz                        |                     | time with time zone      | DateTimeOffset, DateTime, TimeSpan
-Bytea                         | Binary              | bytea                    | byte[], ArraySegment\<byte>
-Oid                           |                     | oid                      | uint
-Xid                           |                     | xid                      | uint
-Cid                           |                     | cid                      | uint
-Oidvector                     |                     | oidvector                | uint[]
-Name                          |                     | name                     | string, char[], char
-InternalChar                  |                     | (internal) char          | byte
-Composite                     |                     | composite types          | T
-Range \| (other NpgsqlDbType) |                     | range types              | NpgsqlRange\<TElement>
-Enum                          |                     | enum types               | TEnum
-Array \| (other NpgsqlDbType) |                     | array types              | Array, IList\<T>, IList
+Varchar                       |                     | character varying           | string, char[], char
+Char                          |                     | character                   | string, char[], char
+Citext                        |                     | citext                      | string, char[], char
+Json                          |                     | json                        | string, char[], char
+Jsonb                         |                     | jsonb                       | string, char[], char
+Xml                           |                     | xml                         | string, char[], char
+Point                         |                     | point                       | NpgsqlPoint
+LSeg                          |                     | lseg                        | NpgsqlLSeg
+Path                          |                     | path                        | NpgsqlPath
+Polygon                       |                     | polygon                     | NpgsqlPolygon
+Line                          |                     | line                        | NpgsqlLine
+Circle                        |                     | circle                      | NpgsqlCircle
+Box                           |                     | box                         | NpgsqlBox
+Bit                           |                     | bit                         | BitArray, bool, string
+Varbit                        |                     | bit varying                 | BitArray, bool, string
+Hstore                        |                     | hstore                      | IDictionary<string, string>
+Uuid                          |                     | uuid                        | Guid
+Cidr                          |                     | cidr                        | ValueTuple<IPAddress, int>, IPAddress, NpgsqlInet
+Inet                          |                     | inet                        | ValueTuple<IPAddress, int>, IPAddress, NpgsqlInet
+MacAddr                       |                     | macaddr                     | PhysicalAddress
+TsQuery                       |                     | tsquery                     | NpgsqlTsQuery
+TsVector                      |                     | tsvector                    | NpgsqlTsVector
+Date                          | Date                | date                        | DateTime, NpgsqlDate
+Interval                      |                     | interval                    | TimeSpan, NpgsqlTimeSpan
+Timestamp                     | DateTime, DateTime2 | timestamp without time zone | DateTime, NpgsqlDateTime
+TimestampTz                   | DateTimeOffset      | timestamp with time zone    | DateTime, DateTimeOffset, NpgsqlDateTime
+Time                          | Time                | time without time zone      | TimeSpan
+TimeTz                        |                     | time with time zone         | DateTimeOffset, DateTime, TimeSpan
+Bytea                         | Binary              | bytea                       | byte[], ArraySegment\<byte>
+Oid                           |                     | oid                         | uint
+Xid                           |                     | xid                         | uint
+Cid                           |                     | cid                         | uint
+Oidvector                     |                     | oidvector                   | uint[]
+Name                          |                     | name                        | string, char[], char
+InternalChar                  |                     | (internal) char             | byte
+Composite                     |                     | composite types             | T
+Range \| (other NpgsqlDbType) |                     | range types                 | NpgsqlRange\<TElement>
+Enum                          |                     | enum types                  | TEnum
+Array \| (other NpgsqlDbType) |                     | array types                 | Array, IList\<T>, IList
 
 Notes when using Range and Array, bitwise-or NpgsqlDbType.Range or NpgsqlDbType.Array with the child type. For example, to construct the NpgsqlDbType for a `int4range`, write `NpgsqlDbType.Range | NpgsqlDbType.Integer`. To construct the NpgsqlDbType for an `int[]`, write `NpgsqlDbType.Array | NpgsqlDbType.Integer`.
 
@@ -166,8 +166,8 @@ For information about enums, [see the Enums and Composites page](enums_and_compo
 | NpgsqlTsQuery          | tsquery
 | NpgsqlTsVector         | tsvector
 | NpgsqlDate             | date
-| NpgsqlDateTime         | timestamp
-| DateTime               | timestamp
+| NpgsqlDateTime         | timestamp without time zone
+| DateTime               | timestamp without time zone
 | DateTimeOffset         | timestamp with time zone
 | TimeSpan               | interval
 | byte[]                 | bytea

--- a/conceptual/Npgsql/types/datetime.md
+++ b/conceptual/Npgsql/types/datetime.md
@@ -14,14 +14,14 @@ yourself with PostgreSQL's types.
 
 The .NET and PostgreSQL types differ in the resolution and range they provide; the .NET type usually have a higher resolution but a lower range than the PostgreSQL types:
 
-PostgreSQL type         | Precision/Range                           | .NET Native Type             | Precision/Range                                | Npgsql .NET Provider-Specific Type
-------------------------|-------------------------------------------|------------------------------|------------------------------------------------|-----------------------------------
-timestamp               | 1 microsecond, 4713BC-294276AD            | DateTime                     | 100 nanoseconds, 1AD-9999AD                    | NpgsqlDateTime
-timestamp with timezone | 1 microsecond, 4713BC-294276AD            | DateTime                     | 100 nanoseconds, 1AD-9999AD                    | NpgsqlDateTime
-date                    | 1 day, 4713BC-5874897AD                   | DateTime                     | 100 nanoseconds, 1AD-9999AD                    | NpgsqlDate
-time                    | 1 microsecond, 0-24 hours                 | TimeSpan                     | 100 nanoseconds, -10,675,199 - 10,675,199 days | N/A
-time with timezone      | 1 microsecond, 0-24 hours                 | DateTimeOffset (ignore date) | 100 nanoseconds, 1AD-9999AD                    | N/A
-interval                | 1 microsecond, -178000000-178000000 years | TimeSpan                     | 100 nanoseconds, -10,675,199 - 10,675,199 days | NpgsqlTimeSpan
+PostgreSQL type             | Precision/Range                           | .NET Native Type             | Precision/Range                                | Npgsql .NET Provider-Specific Type
+----------------------------|-------------------------------------------|------------------------------|------------------------------------------------|-----------------------------------
+timestamp without time zone | 1 microsecond, 4713BC-294276AD            | DateTime                     | 100 nanoseconds, 1AD-9999AD                    | NpgsqlDateTime
+timestamp with time zone    | 1 microsecond, 4713BC-294276AD            | DateTime                     | 100 nanoseconds, 1AD-9999AD                    | NpgsqlDateTime
+date                        | 1 day, 4713BC-5874897AD                   | DateTime                     | 100 nanoseconds, 1AD-9999AD                    | NpgsqlDate
+time without time zone      | 1 microsecond, 0-24 hours                 | TimeSpan                     | 100 nanoseconds, -10,675,199 - 10,675,199 days | N/A
+time with time zone         | 1 microsecond, 0-24 hours                 | DateTimeOffset (ignore date) | 100 nanoseconds, 1AD-9999AD                    | N/A
+interval                    | 1 microsecond, -178000000-178000000 years | TimeSpan                     | 100 nanoseconds, -10,675,199 - 10,675,199 days | NpgsqlTimeSpan
 
 If your needs are met by the .NET native types, it is best that you use them directly with Npgsql.
 If, however, you require the extended range of a PostgreSQL type you can use Npgsql's provider-specific types, which represent PostgreSQL types in an exact way.

--- a/conceptual/Npgsql/types/nodatime.md
+++ b/conceptual/Npgsql/types/nodatime.md
@@ -55,10 +55,10 @@ imestamp is stored. There is no single PostgreSQL type that stores both a date/t
 
 PostgreSQL Type 		| Default NodaTime Type | Additional NodaTime Type      | Notes
 --------------------------------|-----------------------|-------------------------------|-------
-timestamp       		| Instant               | LocalDateTime                 | It's common to store UTC timestamps in databases - you can simply do so and read/write Instant values. You also have the option of readin/writing LocalDateTime, which is a date/time with no information about timezones; this makes sense if you're storing the timezone in a different column and want to read both into a NodaTime ZonedDateTime.
+timestamp without time zone		| Instant               | LocalDateTime                 | It's common to store UTC timestamps in databases - you can simply do so and read/write Instant values. You also have the option of readin/writing LocalDateTime, which is a date/time with no information about timezones; this makes sense if you're storing the timezone in a different column and want to read both into a NodaTime ZonedDateTime.
 timestamp with time zone	| Instant               | ZonedDateTime, OffsetDateTime | This PostgreSQL type stores only a timestamp, assumed to be in UTC. If you read/write this as an Instant, it will be provided as stored with no timezone conversions whatsoever. If, however, you read/write as a ZonedDateTime or OffsetDateTime, the plugin will automatically convert to and from UTC according to your PostgreSQL session's timezone.
 date				| LocalDate             |                               | A simple date with no timezone or offset information.
-time				| LocalTime             |                               | A simple time-of-day, with no timezone or offset information.
+time without time zone	| LocalTime             |                               | A simple time-of-day, with no timezone or offset information.
 time with time zone		| OffsetTime            |                               | This is a PostgreSQL type that stores a time and an offset.
 interval        		| Period                |                               | This is a human interval which does not have a fixed absolute length ("two months" can vary depending on the months in question), and so it is mapped to NodaTime's Period (and not Duration or TimeSpan).
 


### PR DESCRIPTION
@roji, I've updated docs around the time and timestamp DataTypes to contain 'without time zone' text as discussed in the fix for #1886.

Kind Regards,
Warren Chan
Fujitsu Australia