### PR TITLE
Added `Port` to connection string

### DIFF
--- a/conceptual/EFCore.PG/index.md
+++ b/conceptual/EFCore.PG/index.md
@@ -41,7 +41,7 @@ namespace ConsoleApp.PostgreSQL
         public DbSet<Post> Posts { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseNpgsql("Host=my_host;Database=my_db;Username=my_user;Password=my_pw");
+            => optionsBuilder.UseNpgsql("Host=my_host;Port=5432;Database=my_db;Username=my_user;Password=my_pw");
     }
 
     public class Blog
@@ -83,5 +83,5 @@ public void ConfigureServices(IServiceCollection services)
 The Npgsql EF Core provider also supports reverse-engineering a code model from an existing PostgreSQL database ("database-first"). To do so, use dotnet CLI to execute the following:
 
 ```bash
-dotnet ef dbcontext scaffold "Host=my_host;Database=my_db;Username=my_user;Password=my_pw" Npgsql.EntityFrameworkCore.PostgreSQL
+dotnet ef dbcontext scaffold "Host=my_host;Port=5432;Database=my_db;Username=my_user;Password=my_pw" Npgsql.EntityFrameworkCore.PostgreSQL
 ```


### PR DESCRIPTION
I added the `Port` option with Postgres default port value (5432) to the connection string because begginers (as I am) may not know that exists and may try to add the port (as I did, localhost:5432) after the host address.

In my case the EF Core Npgsl package is not used the default Postgres port (5432) so I had to add it manually.

My intention is with this PR that begginers like me, will be able sort out and fix basic connection issues andd they won't try to add the port after the host address.