### PR TITLE
Fix typo referencing "Socket Receive Buffer Size"

### DIFF
--- a/conceptual/Npgsql/performance.md
+++ b/conceptual/Npgsql/performance.md
@@ -60,7 +60,7 @@ You can also control the socket's receive buffer size (not to be confused with N
 
 Writing is somewhat similar - Npgsql has an internally write buffer (also 8K by default). When writing your query's SQL and parameters to PostgreSQL, Npgsql always writes "sequentially", that is, filling up the 8K buffer and flushing it when full. You can use `Write Buffer Size` to control the buffer's size.
 
-You can also control the socket's receive buffer size (not to be confused with Npgsql's internal buffer) by setting the `Socket Receive Buffer Size` connection string parameter.
+You can also control the socket's send buffer size (not to be confused with Npgsql's internal buffer) by setting the `Socket Send Buffer Size` connection string parameter.
 
 ## Avoiding boxing when writing parameter values
 


### PR DESCRIPTION
My understanding is that when writing large values, we are using the socket's send buffer so we should be controlling the `Socket Send Buffer Size` connection string parameter, NOT the receive parameter (this looks like a copy-and-paste error from a similar sentence in the `Reading Large Values` section).