### PR TITLE
Postgres 12+ does not require trigger setup to update generated searc…

### DIFF
--- a/conceptual/EFCore.PG/mapping/full-text-search.md
+++ b/conceptual/EFCore.PG/mapping/full-text-search.md
@@ -68,8 +68,6 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 }
 ```
 
-***
-
 Now generate a migration (`dotnet ef migrations add ....`), and open it with your favorite editor, adding the following:
 
 ```c#
@@ -95,6 +93,7 @@ public partial class CreateProductTable : Migration
     }
 }
 ```
+
 
 ***
 


### PR DESCRIPTION
The instructions to generate a migration and add trigger to update search vector column does not apply to Postgres 12 and above since they use generated column. Hence moving the trigger instructions to Postgres (Older) tab since it creates confusion.