### PR TITLE
Minor typo fixes in code

### DIFF
--- a/conceptual/EFCore.PG/mapping/full-text-search.md
+++ b/conceptual/EFCore.PG/mapping/full-text-search.md
@@ -68,8 +68,6 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 }
 ```
 
-***
-
 Now generate a migration (`dotnet ef migrations add ....`), and open it with your favorite editor, adding the following:
 
 ```c#
@@ -95,6 +93,7 @@ public partial class CreateProductTable : Migration
     }
 }
 ```
+
 
 ***
 

--- a/conceptual/EFCore.PG/mapping/full-text-search.md
+++ b/conceptual/EFCore.PG/mapping/full-text-search.md
@@ -48,11 +48,12 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 {
     modelBuilder.Entity<Product>()
         .HasGeneratedTsVectorColumn(
-            p => b.TsVector,
+            p => p.TsVector,
             "english",  // Text search config
             p => new { p.Name, p.Description })  // Included properties
         .HasIndex(b => b.TsVector)
         .HasMethod("GIN"); // Index method on the search vector (GIN or GIST)
+}
 ```
 
 #### [Older Versions](#tab/older)


### PR DESCRIPTION
This PR fixes two typo issues in Full Text Search documentation

1. `p => b.TsVector` should be `p => p.TsVector`
2. Add close braces to `OnModelCreating()` method
