### PR TITLE
Added link from npgsql.com to its github page.

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,7 +16,7 @@ In addition, providers have been written for Entity Framework Core and for Entit
 ## Getting Help
 
 The best way to get help for Npgsql is to post a question to Stack Overflow and tag it with the `npgsql` tag.
-If you think you've encountered a bug or want to request a feature, open an issue in the appropriate project's github repository.
+If you think you've encountered a bug or want to request a feature, open an issue in the [appropriate project's github repository](https://github.com/npgsql).
 
 ## License
 


### PR DESCRIPTION
The link from the npgsql.com to its github page is not so obvious.
Maybe this is a good place to add it.