### PR TITLE
Add missing namespace for the call to optionsBuilder

### DIFF
--- a/conceptual/EFCore.PG/index.md
+++ b/conceptual/EFCore.PG/index.md
@@ -32,6 +32,7 @@ Below is a `.csproj` file for a console application that uses the Npgsql EF Core
 ```c#
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
+using Npgsql.EntityFrameworkCore.PostgreSQL;
 
 namespace ConsoleApp.PostgreSQL
 {


### PR DESCRIPTION
Came across this while walking someone else through an example.