### PR TITLE
Fix typo in basic.md

### DIFF
--- a/conceptual/Npgsql/types/basic.md
+++ b/conceptual/Npgsql/types/basic.md
@@ -10,7 +10,7 @@ The following shows the mappings used when reading values.
 
 * The default type is returned when using `NpgsqlCommand.ExecuteScalar()`, `NpgsqlDataReader.GetValue()` and similar methods.
 * You can read as other types by calling `NpgsqlDataReader.GetFieldValue<T>()`.
-* Provider-specific types are returne by `NpgsqlDataReader.GetProviderSpecificValue()`.
+* Provider-specific types are returned by `NpgsqlDataReader.GetProviderSpecificValue()`.
 
 PostgreSQL type             | Default .NET type          | Provider-specific type | Other .NET types
 ----------------------------|----------------------------|------------------------|-----------------


### PR DESCRIPTION
The following sentence:

> Provider-specific types are returne by...

Should read:

> Provider-specific types are **returned** by...