### PR TITLE
EF Core 6.0 release and breaking change notes

### DIFF
--- a/conceptual/EFCore.PG/mapping/nts.md
+++ b/conceptual/EFCore.PG/mapping/nts.md
@@ -85,8 +85,8 @@ The following table lists NetTopologySuite operations which are translated to Po
 
 Note that the plugin is far from covering all spatial operations. If an operation you need is missing, please open an issue to request for it.
 
-.NET                                                             | SQL
----------------------------------------------------------------- |-----
+.NET                                                             | SQL                                                                                  | Notes
+---------------------------------------------------------------- |------------------------------------------------------------------------------------- | -----
 geom.Area()                                                      | [ST_Area(geom)](https://postgis.net/docs/ST_Area.html)
 geom.AsBinary()                                                  | [ST_AsBinary(geom)](https://postgis.net/docs/ST_AsBinary.html)
 geom.AsText()                                                    | [ST_AsText(geom)](https://postgis.net/docs/ST_AsText.html)
@@ -104,8 +104,8 @@ geom1.Difference(geom2)                                          | [ST_Differenc
 geom1.Dimension                                                  | [ST_Dimension(geom1)](https://postgis.net/docs/ST_Dimension.html)
 geom1.Disjoint(geom2)                                            | [ST_Disjoint(geom1, geom2)](https://postgis.net/docs/ST_Disjoint.html)
 geom1.Distance(geom2)                                            | [ST_Distance(geom1, geom2)](https://postgis.net/docs/ST_Distance.html)
-EF.Functions.DistanceKnn(geom1, geom2) (v6)                      | [geom1 <-> geom2](https://postgis.net/docs/geometry_distance_knn.html)
-EF.Functions.Distance(geom1, geom2, useSpheriod) (v6)            | [ST_Distance(geom1, geom2, useSpheriod)](https://postgis.net/docs/ST_Distance.html)
+EF.Functions.DistanceKnn(geom1, geom2)                           | [geom1 <-> geom2](https://postgis.net/docs/geometry_distance_knn.html)               | Added in 6.0
+EF.Functions.Distance(geom1, geom2, useSpheriod)                 | [ST_Distance(geom1, geom2, useSpheriod)](https://postgis.net/docs/ST_Distance.html)  | Added in 6.0
 geom1.Envelope                                                   | [ST_Envelope(geom1)](https://postgis.net/docs/ST_Envelope.html)
 geom1.ExactEquals(geom2)                                         | [ST_OrderingEquals(geom1, geom2)](https://postgis.net/docs/ST_OrderingEquals.html)
 lineString.EndPoint                                              | [ST_EndPoint(lineString)](https://postgis.net/docs/ST_EndPoint.html)
@@ -113,6 +113,7 @@ polygon.ExteriorRing                                             | [ST_ExteriorR
 geom1.Equals(geom2)                                              | [geom1 = geom2](https://postgis.net/docs/ST_Geometry_EQ.html)
 geom1.Polygon.EqualsExact(geom2)                                 | [geom1 = geom2](https://postgis.net/docs/ST_Geometry_EQ.html)
 geom1.EqualsTopologically(geom2)                                 | [ST_Equals(geom1, geom2)](https://postgis.net/docs/ST_Equals.html)
+EF.Functions.Force2D                                             | [ST_Force2D(geom)](https://postgis.net/docs/ST_Force2D.html)                         | Added in 6.0
 geom.GeometryType                                                | [GeometryType(geom)](https://postgis.net/docs/GeometryType.html)
 geomCollection.GetGeometryN(i)                                   | [ST_GeometryN(geomCollection, i)](https://postgis.net/docs/ST_GeometryN.html)
 linestring.GetPointN(i)                                          | [ST_PointN(linestring, i)](https://postgis.net/docs/ST_PointN.html)
@@ -123,7 +124,7 @@ lineString.IsClosed()                                            | [ST_IsClosed(
 geomCollection.IsEmpty()                                         | [ST_IsEmpty(geomCollection)](https://postgis.net/docs/ST_IsEmpty.html)
 linestring.IsRing                                                | [ST_IsRing(linestring)](https://postgis.net/docs/ST_IsRing.html)
 geom.IsWithinDistance(geom2,d)                                   | [ST_DWithin(geom1, geom2, d)](https://postgis.net/docs/ST_DWithin.html)
-EF.Functions.IsWithinDistance(geom1, geom2, d, useSpheriod) (v6) | [ST_DWithin(geom1, geom2, d, useSpheriod)](https://postgis.net/docs/ST_DWithin.html)
+EF.Functions.IsWithinDistance(geom1, geom2, d, useSpheriod)      | [ST_DWithin(geom1, geom2, d, useSpheriod)](https://postgis.net/docs/ST_DWithin.html) | Added in 6.0
 geom.IsSimple()                                                  | [ST_IsSimple(geom)](https://postgis.net/docs/ST_IsSimple.html)
 geom.IsValid()                                                   | [ST_IsValid(geom)](https://postgis.net/docs/ST_IsValid.html)
 lineString.Length                                                | [ST_Length(lineString)](https://postgis.net/docs/ST_Length.html)

--- a/conceptual/EFCore.PG/mapping/translations.md
+++ b/conceptual/EFCore.PG/mapping/translations.md
@@ -6,44 +6,56 @@ The Npgsql-specific translations are listed below. Some areas, such as [full-tex
 
 ## Binary functions
 
-.NET                         | SQL                             | Added in
+.NET                         | SQL                             | Notes
 ---------------------------- | ------------------------------- | --------
-bytes[i]                     | get_byte(bytes, i)              | EF Core 5.0
-bytes.Contains(value)        | position(value IN bytes) > 0    | EF Core 5.0
-bytes.Length                 | length(@bytes)                  | EF Core 5.0
-bytes1.SequenceEqual(bytes2) | @bytes = @second                | EF Core 5.0
+bytes[i]                     | get_byte(bytes, i)              | Added in 5.0
+bytes.Contains(value)        | position(value IN bytes) > 0    | Added in 5.0
+bytes.Length                 | length(@bytes)                  | Added in 5.0
+bytes1.SequenceEqual(bytes2) | @bytes = @second                | Added in 5.0
 
 ## Date and time functions
 
-.NET                           | SQL
------------------------------- | ---
-DateTime.Now                   | [now()](https://www.postgresql.org/docs/current/functions-datetime.html)
-DateTime.Today                 | [date_trunc('day', now())](https://www.postgresql.org/docs/current/functions-datetime.html)
-DateTime.UtcNow                | [now() AT TIME ZONE 'UTC'](https://www.postgresql.org/docs/current/functions-datetime.html)
-dateTime.AddDays(1)            | [dateTime + INTERVAL '1 days'](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE)
-dateTime.AddHours(value)       | [dateTime + INTERVAL '1 hours'](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE)
-dateTime.AddMinutes(1)         | [dateTime + INTERVAL '1 minutes'](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE)
-dateTime.AddMonths(1)          | [dateTime + INTERVAL '1 months'](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE)
-dateTime.AddSeconds(1)         | [dateTime + INTERVAL '1 seconds'](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE)
-dateTime.AddYears(1)           | [dateTime + INTERVAL '1 years'](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE)
-dateTime.Date                  | [date_trunc('day', dateTime)](https://www.postgresql.org/docs/current/functions-datetime.html)
-dateTime.Day                   | [date_part('day', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-dateTime.DayOfWeek             | [floor(date_part('dow', dateTime))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-dateTime.DayOfYear             | [date_part('doy', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-dateTime.Hour                  | [date_part('hour', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-dateTime.Minute                | [date_part('minute', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-dateTime.Month                 | [date_part('month', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-dateTime.Second                | [date_part('second', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-dateTime.Year                  | [date_part('year', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-timeSpan.Days                  | [floor(date_part('day', timeSpan))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-timeSpan.Hours                 | [floor(date_part('hour', timeSpan))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-timeSpan.Minutes               | [floor(date_part('minute', timeSpan))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-timeSpan.Seconds               | [floor(date_part('second', timeSpan))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-timeSpan.Milliseconds          | [floor(date_part('millisecond', timeSpan))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-timeSpan.Milliseconds          | [floor(date_part('millisecond', timeSpan))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)
-dateTime1 - dateTime2          | [dateTime1 - dateTime2](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE)
-new DateTime(year, month, day) | [make_date(year, month, day)](https://www.postgresql.org/docs/current/functions-datetime.html)
-new DateTime(y, m, d, h, m, s) | [make_timestamp(y, m, d, h, m, s)](https://www.postgresql.org/docs/current/functions-datetime.html)
+> [!NOTE]
+> Since version 6.0, many of the below DateTime translations are also supported on DateTimeOffset.
+
+.NET                                 | SQL                                                                                                                         | Notes
+------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- | --------
+DateTime.UtcNow (6.0+)               | [now()](https://www.postgresql.org/docs/current/functions-datetime.html)                                                    | See 6.0 release notes
+DateTime.Now (6.0+)                  | [now()::timestamp](https://www.postgresql.org/docs/current/functions-datetime.html)                                         | See 6.0 release notes
+DateTime.Today (6.0+)                | [date_trunc('day', now()::timestamp)](https://www.postgresql.org/docs/current/functions-datetime.html)                      | See 6.0 release notes
+DateTime.UtcNow (legacy)             | [now() AT TIME ZONE 'UTC'](https://www.postgresql.org/docs/current/functions-datetime.html)                                 | See 6.0 release notes
+DateTime.Now (legacy)                | [now()](https://www.postgresql.org/docs/current/functions-datetime.html)                                                    | See 6.0 release notes
+DateTime.Today (legacy)              | [date_trunc('day', now())](https://www.postgresql.org/docs/current/functions-datetime.html)                                 | See 6.0 release notes
+dateTime.AddDays(1)                  | [dateTime + INTERVAL '1 days'](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE)    |
+dateTime.AddHours(value)             | [dateTime + INTERVAL '1 hours'](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE)   |
+dateTime.AddMinutes(1)               | [dateTime + INTERVAL '1 minutes'](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE) |
+dateTime.AddMonths(1)                | [dateTime + INTERVAL '1 months'](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE)  |
+dateTime.AddSeconds(1)               | [dateTime + INTERVAL '1 seconds'](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE) |
+dateTime.AddYears(1)                 | [dateTime + INTERVAL '1 years'](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE)   |
+dateTime.Date                        | [date_trunc('day', dateTime)](https://www.postgresql.org/docs/current/functions-datetime.html)                              |
+dateTime.Day                         | [date_part('day', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)                          |
+dateTime.DayOfWeek                   | [floor(date_part('dow', dateTime))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)                   |
+dateTime.DayOfYear                   | [date_part('doy', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)                          |
+dateTime.Hour                        | [date_part('hour', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)                         |
+dateTime.Minute                      | [date_part('minute', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)                       |
+dateTime.Month                       | [date_part('month', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)                        |
+dateTime.Second                      | [date_part('second', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)                       |
+dateTime.Year                        | [date_part('year', dateTime)::INT](https://www.postgresql.org/docs/current/functions-datetime.html)                         |
+dateTime.ToUniversalTime             | [dateTime::timestamptz](https://www.postgresql.org/docs/current/datatype-datetime.html#id-1.5.7.13.18.7)                    | Added in 6.0
+dateTime.ToLocalTime                 | [dateTime::timestamp](https://www.postgresql.org/docs/current/datatype-datetime.html#id-1.5.7.13.18.7)                      | Added in 6.0
+timeSpan.Days                        | [floor(date_part('day', timeSpan))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)                   |
+timeSpan.Hours                       | [floor(date_part('hour', timeSpan))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)                  |
+timeSpan.Minutes                     | [floor(date_part('minute', timeSpan))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)                |
+timeSpan.Seconds                     | [floor(date_part('second', timeSpan))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)                |
+timeSpan.Milliseconds                | [floor(date_part('millisecond', timeSpan))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)           |
+timeSpan.Milliseconds                | [floor(date_part('millisecond', timeSpan))::INT](https://www.postgresql.org/docs/current/functions-datetime.html)           |
+dateTime1 - dateTime2                | [dateTime1 - dateTime2](https://www.postgresql.org/docs/current/functions-datetime.html#OPERATORS-DATETIME-TABLE)           |
+new DateTime(year, month, day)       | [make_date(year, month, day)](https://www.postgresql.org/docs/current/functions-datetime.html)                              |
+new DateTime(y, m, d, h, m, s)       | [make_timestamp(y, m, d, h, m, s)](https://www.postgresql.org/docs/current/functions-datetime.html)                         |
+new DateTime(y, m, d, h, m, s, kind) | [make_timestamp or make_timestamptz](https://www.postgresql.org/docs/current/functions-datetime.html), based on `king`      | Added in 6.0
+
+> [!NOTE]
+> See also Npgsql's [NodaTime support](/efcore/mapping/nodatime.html).
 
 ## Network functions
 
@@ -109,9 +121,9 @@ Math.Truncate(d)        | trunc(d)
 
 ## String functions
 
-.NET                                                          | SQL                                                    | Added in
+.NET                                                          | SQL                                                    | Notes
 ------------------------------------------------------------- | ------------------------------------------------------ | --------
-EF.Functions.Collate(operand, collation)                      | operand COLLATE collation                              | EF Core 5.0
+EF.Functions.Collate(operand, collation)                      | operand COLLATE collation                              | Added in 5.0
 EF.Functions.Like(matchExpression, pattern)                   | matchExpression LIKE pattern
 EF.Functions.Like(matchExpression, pattern, escapeCharacter)  | matchExpression LIKE pattern ESCAPE escapeCharacter
 EF.Functions.ILike(matchExpression, pattern)                  | [matchExpression ILIKE pattern](../misc/collations-and-case-sensitivity.md)
@@ -123,9 +135,9 @@ string.IsNullOrWhiteSpace(value)                              | value IS NULL OR
 stringValue.CompareTo(strB)                                   | CASE WHEN stringValue = strB THEN 0 ... END
 stringValue.Contains(value)                                   | strpos(stringValue, value) > 0
 stringValue.EndsWith(value)                                   | stringValue LIKE '%' \|\| value
-stringValue.FirstOrDefault()                                  | substr(stringValue, 1, 1)                              | EF Core 5.0
+stringValue.FirstOrDefault()                                  | substr(stringValue, 1, 1)                              | Added in 5.0
 stringValue.IndexOf(value)                                    | strpos(stringValue, value) - 1
-stringValue.LastOrDefault()                                   | substr(stringValue, length(stringValue), 1)            | EF Core 5.0
+stringValue.LastOrDefault()                                   | substr(stringValue, length(stringValue), 1)            | Added in 5.0
 stringValue.Length                                            | length(stringValue)
 stringValue.PadLeft(length)                                   | lpad(stringValue, length)
 stringValue.PadLeft(length, char)                             | lpad(stringValue, length, char)

--- a/conceptual/EFCore.PG/release-notes/6.0.md
+++ b/conceptual/EFCore.PG/release-notes/6.0.md
@@ -46,7 +46,7 @@ Note: The below notes will use the PostgreSQL aliases `timestamptz` to refer to 
   * If the column really should store non-UTC timestamps (local or unspecified), change the property's type to [LocalDateTime](https://nodatime.org/3.0.x/api/NodaTime.LocalDateTime.html) instead; this will maintain the mapping to `timestamp`. This is usually discouraged, but can be a temporary solution before transitioning to `timestamptz`.
 * When reading `timestamptz` as [ZonedDateTime](https://nodatime.org/3.0.x/api/NodaTime.ZonedDateTime.html) or [OffsetDateTime](https://nodatime.org/3.0.x/api/NodaTime.OffsetDateTime.html), UTC values are always returned. Previously, local values based on the PostgreSQL `TimeZone` parameter were returned.
 
-[See the Npgsql docs]() for additional lower-level changes to timestamp handling.
+See the Npgsql docs for additional lower-level changes to timestamp handling.
 
 #### Opting out of the new timestamp mapping logic
 
@@ -70,7 +70,7 @@ SELECT "CreateOn", pg_typeof("CreateOn") AS type FROM "Blogs";
 
 Results in:
 
-```
+```text
       CreateOn       |            type
 ---------------------+-----------------------------
  2020-01-01 12:00:00 | timestamp without time zone
@@ -84,7 +84,7 @@ ALTER TABLE "Blogs" ALTER COLUMN "CreateOn" TYPE timestamp with time zone;
 
 When converting the `timestamp without time zone` column to `timestamp with time zone`, PostgreSQL will assume that existing values are local timestamps, and will convert them to UTC based on the `TimeZone` parameter. Performing the above query will result in something like:
 
-```
+```text
         CreateOn        |           type
 ------------------------+--------------------------
  2020-01-01 12:00:00+02 | timestamp with time zone
@@ -98,7 +98,7 @@ migrationBuilder.Sql("SET TimeZone='UTC'");
 
 This will ensure that no time zone conversions will be applied when converting the columns:
 
-```
+```output
         CreateOn        |           type
 ------------------------+--------------------------
  2020-01-01 14:00:00+02 | timestamp with time zone

--- a/conceptual/EFCore.PG/release-notes/6.0.md
+++ b/conceptual/EFCore.PG/release-notes/6.0.md
@@ -1,10 +1,110 @@
 # 6.0 Release Notes
 
-Version 6.0 of the Npgsql Entity Framework Core provider is in development, and will be released at the same time as EF Core 6.0. Monthly previews are available on nuget.org, which work with the corresponding EF Core preview.
+The release candidate of Npgsql Entity Framework Core provider version 6.0 has been released and is available on nuget. This version works with [version 6.0 of Entity Framework Core](https://docs.microsoft.com/ef/core/what-is-new/ef-core-6.0/whatsnew), and brings new Npgsql features in addition to the general EF Core changes.
+
+Npgsql 6.0 brings some major breaking changes and is not a simple in-place upgrade. Carefully read the breaking change notes below and upgrade with care.
+
+## New features
+
+* Timestamp mapping rationalization and improvements
+    * Support for `timestamp with time zone` and `timestamp without time zone` has been rationalized and simplified, as well as the DateTime and NodaTime mappings to these database types (see breaking changes below)
+    * UTC timestamps have been cleanly separated from non-UTC timestamps, aligning with the PostgreSQL types. The former are represented by `timestamp with time zone` and DateTime with Kind UTC, the latter by `timestamp without time zone` and DateTime with Kind Local or Unspecified. It is recommended to use UTC timestamps where possible.
+    * Npgsql no longer performs any implicit timezone conversions when reading or writing any timestamp value - the value in the database is what you get, and the machine timezone no longer plays any role when reading/writing values.
+    * Npgsql no longer supports date/time representations which cannot be fully round-tripped to the database. If it can't be fully stored as-is, you can't write it.
+    * A compatibility switch enables opting out of the new behavior, to maintain backwards compatibility.
+* Other date/time improvements
+    * Support for the new [.NET DateOnly and TimeOnly types](https://devblogs.microsoft.com/dotnet/date-time-and-time-zone-enhancements-in-net-6/).
+    * Most [DateTimeOffset](https://docs.microsoft.com/dotnet/api/system.datetimeoffset) members and methods are now translated.
+    * Many NodaTime translations have been added for [ZonedDateTime](https://nodatime.org/3.0.x/api/NodaTime.ZonedDateTime.html), [Period](https://nodatime.org/3.0.x/api/NodaTime.Period.html), [DateInterval](https://nodatime.org/3.0.x/api/NodaTime.DateInterval.html) and others.
+    * PostgreSQL `daterange` is now mapped to NodaTime [DateInterval](https://nodatime.org/3.0.x/api/NodaTime.DateInterval.html), and most methods on it are translated.
+* The provider is now fully annotated for nullable reference types.
+* Support for the PostgreSQL [ltree](https://www.postgresql.org/docs/current/ltree.html) type, which represents labels of data stored in a hierarchical tree-like structure.
+* Multiple spatial translations have been added for NetTopologySuite ([DistanceKnn, <->](https://github.com/npgsql/efcore.pg/issues/1827), [ST_Force2D](https://github.com/npgsql/efcore.pg/issues/1917), [ST_Distance and ST_DWithin with spheriod](https://github.com/npgsql/efcore.pg/issues/1638)).
+
+The full list of issues for this release is [available here](https://github.com/npgsql/efcore.pg/milestone/34?closed=1).
 
 ## Breaking changes
 
-### Value converters for array/list properties need to use a specia new API
+### Major changes to timestamp mapping
+
+> [!NOTE]
+> It is possible to opt out of these changes to maintain backwards compatibility, see below.
+
+Note: The below notes will use the PostgreSQL aliases `timestamptz` to refer to `timestamp with time zone`, and `timestamp` to refer to `timestamp without time zone`. Note that `timestamptz` represents a UTC timestamp and does not store a timezone in the database.
+
+* DateTime properties now map to `timestamptz` by default, instead of to `timestamp`; although storing UTC timestamps is the recommended pattern, this will cause the first migration to change your column type.
+    * If the intention is to store point-in-time or UTC timestamps, it's recommended to allow the migration to occur (see migration notes below).
+    * If the column really should store non-UTC timestamps (local or unspecified), [explicitly set the column type back to `timestamp`](https://docs.microsoft.com/ef/core/modeling/entity-properties#column-data-types). This is usually discouraged, but can be a temporary solution before transitioning to `timestamptz`.
+* It is no longer possible to write DateTime with Kinds Local or Unspecified to `timestamptz` properties (which are the default for DateTime). Previously, Npgsql allowed writing those, performing timezone conversions from local to UTC. To write to `timestamptz`, provide a UTC DateTime. Similarly, it is no longer possible to write DateTime with Kind UTC to a `timestamp` column.
+* `timestamptz` values are now read back as DateTime with Kind=UTC, without any conversions; these were previously returned as local DateTime, converted to the local machine's timezone. When reading `timestamptz` values as [DateTimeOffset](https://docs.microsoft.com/dotnet/api/system.datetimeoffset), UTC values (offset 0) are always returned.
+* It is no longer possible to write [DateTimeOffset](https://docs.microsoft.com/dotnet/api/system.datetimeoffset) with offsets other than 0 (UTC), since these cannot be represented in PostgreSQL.
+
+#### NodaTime changes
+
+* Properties with type [Instant](https://nodatime.org/3.0.x/api/NodaTime.Instant.html) are now mapped to `timestamptz` columns, and not to `timestamp`, since they represent a universally agreed-upon point in time. Although storing UTC timestamps is the recommended pattern, this will cause the first migration to change your column type.
+    * If the intention is to store point-in-time or UTC timestamps, it's recommended to allow the migration to occur (see migration notes below).
+    * If the column really should store non-UTC timestamps (local or unspecified), change the property's type to [LocalDateTime](https://nodatime.org/3.0.x/api/NodaTime.LocalDateTime.html) instead; this will maintain the mapping to `timestamp`. This is usually discouraged, but can be a temporary solution before transitioning to `timestamptz`.
+* When reading `timestamptz` as [ZonedDateTime](https://nodatime.org/3.0.x/api/NodaTime.ZonedDateTime.html) or [OffsetDateTime](https://nodatime.org/3.0.x/api/NodaTime.OffsetDateTime.html), UTC values are always returned. Previously, local values based on the PostgreSQL `TimeZone` parameter were returned.
+
+[See the Npgsql docs]() for additional lower-level changes to timestamp handling.
+
+#### Opting out of the new timestamp mapping logic
+
+The changes described above are far-reaching, and may break applications in various ways. You can upgrade to version 6.0 but opt out of the new mapping by enabling the `Npgsql.EnableLegacyTimestampBehavior` [AppContext switch](https://docs.microsoft.com/en-us/dotnet/api/system.appcontext?view=net-5.0):
+
+To revert to the legacy timestamp behavior, add the following at the start of your application, before any EF Core operations are invoked:
+
+```c#
+AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+```
+
+#### Migrating columns from timestamp to timestamptz
+
+As a result of the above changes, the first migration created after upgrading to 6.0 will alter the columns for all DateTime and Instant properties from `timestamp` to `timestamptz`. If these columns are meant to store point-in-time or UTC timestamps (the recommended practice), then it's best to let this migration proceed; but care must be taken.
+
+As a starting point, let's assume your existing `timestamp` column has the timestamp `2020-01-01 12:00:00`:
+
+```sql
+SELECT "CreateOn", pg_typeof("CreateOn") AS type FROM "Blogs";
+```
+
+Results in:
+
+```
+      CreateOn       |            type
+---------------------+-----------------------------
+ 2020-01-01 12:00:00 | timestamp without time zone
+```
+
+The migration generated by version 6.0 will cause the following SQL to be executed:
+
+```sql
+ALTER TABLE "Blogs" ALTER COLUMN "CreateOn" TYPE timestamp with time zone;
+```
+
+When converting the `timestamp without time zone` column to `timestamp with time zone`, PostgreSQL will assume that existing values are local timestamps, and will convert them to UTC based on the `TimeZone` parameter. Performing the above query will result in something like:
+
+```
+        CreateOn        |           type
+------------------------+--------------------------
+ 2020-01-01 12:00:00+02 | timestamp with time zone
+```
+
+This means that your new `timestamptz` column now contains 10:00 UTC, which is probably not what you want: if the original values were in fact UTC values, you need them to be preserved as-is, with only the column type changing. To do this, edit your migration and add the following to the top of your migration's Up and Down methods:
+
+```c#
+migrationBuilder.Sql("SET TimeZone='UTC'");
+```
+
+This will ensure that no time zone conversions will be applied when converting the columns:
+
+```
+        CreateOn        |           type
+------------------------+--------------------------
+ 2020-01-01 14:00:00+02 | timestamp with time zone
+```
+
+### Value converters for array/list properties need to use a special new API
 
 Previously, it was possible to configure value converters for array/list properties with the general EF Core API:
 

--- a/conceptual/EFCore.PG/release-notes/6.0.md
+++ b/conceptual/EFCore.PG/release-notes/6.0.md
@@ -7,16 +7,16 @@ Npgsql 6.0 brings some major breaking changes and is not a simple in-place upgra
 ## New features
 
 * Timestamp mapping rationalization and improvements
-    * Support for `timestamp with time zone` and `timestamp without time zone` has been rationalized and simplified, as well as the DateTime and NodaTime mappings to these database types (see breaking changes below)
-    * UTC timestamps have been cleanly separated from non-UTC timestamps, aligning with the PostgreSQL types. The former are represented by `timestamp with time zone` and DateTime with Kind UTC, the latter by `timestamp without time zone` and DateTime with Kind Local or Unspecified. It is recommended to use UTC timestamps where possible.
-    * Npgsql no longer performs any implicit timezone conversions when reading or writing any timestamp value - the value in the database is what you get, and the machine timezone no longer plays any role when reading/writing values.
-    * Npgsql no longer supports date/time representations which cannot be fully round-tripped to the database. If it can't be fully stored as-is, you can't write it.
-    * A compatibility switch enables opting out of the new behavior, to maintain backwards compatibility.
+  * Support for `timestamp with time zone` and `timestamp without time zone` has been rationalized and simplified, as well as the DateTime and NodaTime mappings to these database types (see breaking changes below)
+  * UTC timestamps have been cleanly separated from non-UTC timestamps, aligning with the PostgreSQL types. The former are represented by `timestamp with time zone` and DateTime with Kind UTC, the latter by `timestamp without time zone` and DateTime with Kind Local or Unspecified. It is recommended to use UTC timestamps where possible.
+  * Npgsql no longer performs any implicit timezone conversions when reading or writing any timestamp value - the value in the database is what you get, and the machine timezone no longer plays any role when reading/writing values.
+  * Npgsql no longer supports date/time representations which cannot be fully round-tripped to the database. If it can't be fully stored as-is, you can't write it.
+  * A compatibility switch enables opting out of the new behavior, to maintain backwards compatibility.
 * Other date/time improvements
-    * Support for the new [.NET DateOnly and TimeOnly types](https://devblogs.microsoft.com/dotnet/date-time-and-time-zone-enhancements-in-net-6/).
-    * Most [DateTimeOffset](https://docs.microsoft.com/dotnet/api/system.datetimeoffset) members and methods are now translated.
-    * Many NodaTime translations have been added for [ZonedDateTime](https://nodatime.org/3.0.x/api/NodaTime.ZonedDateTime.html), [Period](https://nodatime.org/3.0.x/api/NodaTime.Period.html), [DateInterval](https://nodatime.org/3.0.x/api/NodaTime.DateInterval.html) and others.
-    * PostgreSQL `daterange` is now mapped to NodaTime [DateInterval](https://nodatime.org/3.0.x/api/NodaTime.DateInterval.html), and most methods on it are translated.
+  * Support for the new [.NET DateOnly and TimeOnly types](https://devblogs.microsoft.com/dotnet/date-time-and-time-zone-enhancements-in-net-6/).
+  * Most [DateTimeOffset](https://docs.microsoft.com/dotnet/api/system.datetimeoffset) members and methods are now translated.
+  * Many NodaTime translations have been added for [ZonedDateTime](https://nodatime.org/3.0.x/api/NodaTime.ZonedDateTime.html), [Period](https://nodatime.org/3.0.x/api/NodaTime.Period.html), [DateInterval](https://nodatime.org/3.0.x/api/NodaTime.DateInterval.html) and others.
+  * PostgreSQL `daterange` is now mapped to NodaTime [DateInterval](https://nodatime.org/3.0.x/api/NodaTime.DateInterval.html), and most methods on it are translated.
 * The provider is now fully annotated for nullable reference types.
 * Support for the PostgreSQL [ltree](https://www.postgresql.org/docs/current/ltree.html) type, which represents labels of data stored in a hierarchical tree-like structure.
 * Multiple spatial translations have been added for NetTopologySuite ([DistanceKnn, <->](https://github.com/npgsql/efcore.pg/issues/1827), [ST_Force2D](https://github.com/npgsql/efcore.pg/issues/1917), [ST_Distance and ST_DWithin with spheriod](https://github.com/npgsql/efcore.pg/issues/1638)).
@@ -33,8 +33,8 @@ The full list of issues for this release is [available here](https://github.com/
 Note: The below notes will use the PostgreSQL aliases `timestamptz` to refer to `timestamp with time zone`, and `timestamp` to refer to `timestamp without time zone`. Note that `timestamptz` represents a UTC timestamp and does not store a timezone in the database.
 
 * DateTime properties now map to `timestamptz` by default, instead of to `timestamp`; although storing UTC timestamps is the recommended pattern, this will cause the first migration to change your column type.
-    * If the intention is to store point-in-time or UTC timestamps, it's recommended to allow the migration to occur (see migration notes below).
-    * If the column really should store non-UTC timestamps (local or unspecified), [explicitly set the column type back to `timestamp`](https://docs.microsoft.com/ef/core/modeling/entity-properties#column-data-types). This is usually discouraged, but can be a temporary solution before transitioning to `timestamptz`.
+  * If the intention is to store point-in-time or UTC timestamps, it's recommended to allow the migration to occur (see migration notes below).
+  * If the column really should store non-UTC timestamps (local or unspecified), [explicitly set the column type back to `timestamp`](https://docs.microsoft.com/ef/core/modeling/entity-properties#column-data-types). This is usually discouraged, but can be a temporary solution before transitioning to `timestamptz`.
 * It is no longer possible to write DateTime with Kinds Local or Unspecified to `timestamptz` properties (which are the default for DateTime). Previously, Npgsql allowed writing those, performing timezone conversions from local to UTC. To write to `timestamptz`, provide a UTC DateTime. Similarly, it is no longer possible to write DateTime with Kind UTC to a `timestamp` column.
 * `timestamptz` values are now read back as DateTime with Kind=UTC, without any conversions; these were previously returned as local DateTime, converted to the local machine's timezone. When reading `timestamptz` values as [DateTimeOffset](https://docs.microsoft.com/dotnet/api/system.datetimeoffset), UTC values (offset 0) are always returned.
 * It is no longer possible to write [DateTimeOffset](https://docs.microsoft.com/dotnet/api/system.datetimeoffset) with offsets other than 0 (UTC), since these cannot be represented in PostgreSQL.
@@ -42,8 +42,8 @@ Note: The below notes will use the PostgreSQL aliases `timestamptz` to refer to 
 #### NodaTime changes
 
 * Properties with type [Instant](https://nodatime.org/3.0.x/api/NodaTime.Instant.html) are now mapped to `timestamptz` columns, and not to `timestamp`, since they represent a universally agreed-upon point in time. Although storing UTC timestamps is the recommended pattern, this will cause the first migration to change your column type.
-    * If the intention is to store point-in-time or UTC timestamps, it's recommended to allow the migration to occur (see migration notes below).
-    * If the column really should store non-UTC timestamps (local or unspecified), change the property's type to [LocalDateTime](https://nodatime.org/3.0.x/api/NodaTime.LocalDateTime.html) instead; this will maintain the mapping to `timestamp`. This is usually discouraged, but can be a temporary solution before transitioning to `timestamptz`.
+  * If the intention is to store point-in-time or UTC timestamps, it's recommended to allow the migration to occur (see migration notes below).
+  * If the column really should store non-UTC timestamps (local or unspecified), change the property's type to [LocalDateTime](https://nodatime.org/3.0.x/api/NodaTime.LocalDateTime.html) instead; this will maintain the mapping to `timestamp`. This is usually discouraged, but can be a temporary solution before transitioning to `timestamptz`.
 * When reading `timestamptz` as [ZonedDateTime](https://nodatime.org/3.0.x/api/NodaTime.ZonedDateTime.html) or [OffsetDateTime](https://nodatime.org/3.0.x/api/NodaTime.OffsetDateTime.html), UTC values are always returned. Previously, local values based on the PostgreSQL `TimeZone` parameter were returned.
 
 [See the Npgsql docs]() for additional lower-level changes to timestamp handling.


### PR DESCRIPTION
Includes documentation on the timestamp handling changes.

Closes #115

@vonzshik @NinoFloris this is the EF Core side of things - I will work on the ADO.NET notes later today.

(don't forget these are docs so we can always improve them later - we should merge these soon since that needs to happen before we release rc1)