### PR TITLE
Add missing .HasMethod("GIN") in FTS example

### DIFF
--- a/conceptual/EFCore.PG/mapping/full-text-search.md
+++ b/conceptual/EFCore.PG/mapping/full-text-search.md
@@ -115,6 +115,7 @@ Version 5.0.0 of the provider includes sugar for defining the appropriate expres
 ```c#
 modelBuilder.Entity<Blog>()
     .HasIndex(b => new { b.Title, b.Description })
+    .HasMethod("GIN")
     .IsTsVectorExpressionIndex("english");
 ```
 


### PR DESCRIPTION
Without this it won't make a GIN index which is useless for FTS.