### PR TITLE
Fix typo in 6.0 release notes

### DIFF
--- a/conceptual/Npgsql/release-notes/6.0.md
+++ b/conceptual/Npgsql/release-notes/6.0.md
@@ -281,7 +281,7 @@ Note: version 6.0.0 and 6.0.1 changed parameter matching to be case-sensitive. T
 
 ### The provider-specific date/time types have been obsoleted
 
-Npgsql contains provider-specific `NpgsqlDateTime`, `NpgsqlDate` and `NpgsqlTimeSpan` types, which were designed to provider the same APIs as the corresponding built-in BCL types, but to support the full range of the PostgreSQL types. These types were buggy and inefficient in many ways, and have been obsoleted; they will be removed in Npgsql 7.0.
+Npgsql contains provider-specific `NpgsqlDateTime`, `NpgsqlDate` and `NpgsqlTimeSpan` types, which were designed to provide the same APIs as the corresponding built-in BCL types, but to support the full range of the PostgreSQL types. These types were buggy and inefficient in many ways, and have been obsoleted; they will be removed in Npgsql 7.0.
 
 Instead of the obsoleted types, use the following techniques:
 


### PR DESCRIPTION
The sentence:

> ...which were designed to **provider** the same APIs...

Should read:

> ...which were designed to **provide** the same APIs...