### PR TITLE
Build API documentation from docs branches

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -37,14 +37,14 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: npgsql/npgsql
-        ref: stable
+        ref: docs
         path: Npgsql
 
     - name: Checkout EFCore.PG
       uses: actions/checkout@v3
       with:
         repository: npgsql/Npgsql.EntityFrameworkCore.PostgreSQL
-        ref: stable
+        ref: docs
         path: EFCore.PG
 
     # Setup software


### PR DESCRIPTION
In Npgsql and EFCore.PG, instead of from the stable branch, which I'm deleting. We used to merge releases to stable, but that's just a hassle.