### PR TITLE
Update write mapping to include Stream->bytea for npgsql 7+

### DIFF
--- a/conceptual/Npgsql/types/basic.md
+++ b/conceptual/Npgsql/types/basic.md
@@ -106,7 +106,7 @@ json                        |                                            | strin
 jsonb                       |                                            | string, char[], char                    | Jsonb                 |
 xml                         |                                            | string, char[], char                    | Xml                   |
 uuid                        | Guid                                       |                                         | Uuid                  |
-bytea                       | byte[]                                     | ArraySegment\<byte\>                    | Bytea                 | Binary
+bytea                       | byte[]                                     | ArraySegment\<byte\>, Stream (7.0+)     | Bytea                 | Binary
 timestamp with time zone    | DateTime (Utc)<sup>1</sup>, DateTimeOffset |                                         | TimestampTz           | DateTime<sup>2</sup>, DateTimeOffset
 timestamp without time zone | DateTime (Local/Unspecified)<sup>1</sup>   |                                         | Timestamp             | DateTime2
 date                        | DateOnly (6.0+)                            | DateTime                                | Date                  | Date


### PR DESCRIPTION
I noticed that support for writing a CLR Stream into a bytea column was added in https://github.com/npgsql/npgsql/issues/4466
I've been using it and it works great. I noticed the documentation needed an update to indicate this was a possibility