### PR TITLE
Update contributors in release notes.

### DIFF
--- a/conceptual/EFCore.PG/release-notes/3.1.md
+++ b/conceptual/EFCore.PG/release-notes/3.1.md
@@ -52,6 +52,12 @@ More information is available in [the page about generated properties](../modeli
 
 Thank you very much to the following people who have contributed to the individual 3.x releases.
 
+### [Milestone 3.1.11](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A3.1.11)
+
+| Contributor                      | Assigned issues                                                                                             |
+| -------------------------------- | -----------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji) | [5](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A3.1.11+is%3Aclosed+assignee%3Aroji) |
+
 ### [Milestone 3.1.7](https://github.com/npgsql/EFCore.PG/issues?q=is%3Aissue+milestone%3A3.1.7)
 
 Contributor                                        | Assigned issues

--- a/conceptual/EFCore.PG/release-notes/5.0.md
+++ b/conceptual/EFCore.PG/release-notes/5.0.md
@@ -53,13 +53,60 @@ Previously, when `IsCreatedConcurrently` was used to configure an index without 
 
 A big thank you to all the following people who contributed to the 5.0 release!
 
-### [Milestone 5.0.0](https://github.com/npgsql/EFCore.PG/issues?q=milestone%3A5.0.0+)
+### [Milestone 5.0.10](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.10)
 
-Contributor                                    | Assigned issues
----------------------------------------------- | ----------------:|
-[@artfulsage](https://github.com/artfulsage)   | [1](https://github.com/npgsql/EFCore.PG/issues?q=milestone%3A5.0.0+assignee%3Aartfulsage+)
-[@cloudlucky](https://github.com/cloudlucky)   | [1](https://github.com/npgsql/EFCore.PG/issues?q=milestone%3A5.0.0+assignee%3Acloudlucky+)
-[@plamen-i](https://github.com/plamen-i)       | [1](https://github.com/npgsql/EFCore.PG/issues?q=milestone%3A5.0.0+assignee%3Aplamen-i)
-[@Quogu](https://github.com/Quogu)             | [1](https://github.com/npgsql/EFCore.PG/issues?q=milestone%3A5.0.0+assignee%3AQuogu+)
-[@YohDeadfall](https://github.com/yohdeadfall) | [1](https://github.com/npgsql/EFCore.PG/issues?q=milestone%3A5.0.0+assignee%3Ayohdeadfall+)
-[@roji](https://github.com/roji)               | [45](https://github.com/npgsql/EFCore.PG/issues?q=milestone%3A5.0.0+assignee%3Aroji)
+| Contributor                                    | Assigned issues                                                                                                    |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji)               | [3](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.10+is%3Aclosed+assignee%3Aroji)        |
+| [@dmitrynovik](https://github.com/dmitrynovik) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.10+is%3Aclosed+assignee%3Admitrynovik) |
+
+### [Milestone 5.0.7](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.7)
+
+| Contributor                              | Assigned issues                                                                                                |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji)         | [5](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.7+is%3Aclosed+assignee%3Aroji)     |
+| [@nathan-c](https://github.com/nathan-c) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.7+is%3Aclosed+assignee%3Anathan-c) |
+
+### [Milestone 5.0.6](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.6)
+
+| Contributor                          | Assigned issues                                                                                              |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji)     | [2](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.6+is%3Aclosed+assignee%3Aroji)   |
+| [@kakone](https://github.com/kakone) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.6+is%3Aclosed+assignee%3Akakone) |
+
+### [Milestone 5.0.5.1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.5.1)
+
+| Contributor                              | Assigned issues                                                                                                  |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------:|
+| [@fsibilla](https://github.com/fsibilla) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.5.1+is%3Aclosed+assignee%3Afsibilla) |
+| [@roji](https://github.com/roji)         | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.5.1+is%3Aclosed+assignee%3Aroji)     |
+
+### [Milestone 5.0.5](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.5)
+
+| Contributor                                            | Assigned issues                                                                                                       |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji)                       | [8](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.5+is%3Aclosed+assignee%3Aroji)            |
+| [@DanielAdolfsson](https://github.com/DanielAdolfsson) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.5+is%3Aclosed+assignee%3ADanielAdolfsson) |
+
+### [Milestone 5.0.2](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.2)
+
+| Contributor                      | Assigned issues                                                                                            |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji) | [6](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.2+is%3Aclosed+assignee%3Aroji) |
+
+### [Milestone 5.0.1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.1)
+
+| Contributor                          | Assigned issues                                                                                              |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji)     | [4](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.1+is%3Aclosed+assignee%3Aroji)   |
+| [@akilin](https://github.com/akilin) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.1+is%3Aclosed+assignee%3Aakilin) |
+
+### [Milestone 5.0.0](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.0)
+
+| Contributor                                  | Assigned issues                                                                                                  |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji)             | [50](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.0+is%3Aclosed+assignee%3Aroji)      |
+| [@artfulsage](https://github.com/artfulsage) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.0+is%3Aclosed+assignee%3Aartfulsage) |
+| [@cloudlucky](https://github.com/cloudlucky) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.0+is%3Aclosed+assignee%3Acloudlucky) |
+| [@plamen-i](https://github.com/plamen-i)     | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.0+is%3Aclosed+assignee%3Aplamen-i)   |
+| [@Quogu](https://github.com/Quogu)           | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A5.0.0+is%3Aclosed+assignee%3AQuogu)      |

--- a/conceptual/EFCore.PG/release-notes/6.0.md
+++ b/conceptual/EFCore.PG/release-notes/6.0.md
@@ -191,3 +191,71 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 ### Trigrams and FuzzyStringMatch plugins are now built-in
 
 The Npgsql.EntityFrameworkCore.PostgreSQL.Trigrams and Npgsql.EntityFrameworkCore.PostgreSQL.FuzzyStringMatch plugins have been integrated into the main provider; as a result, there are no 6.0 versions of these nuget packages - simply remove the package references from your project when upgrading to 6.0.0.
+
+## Contributors
+
+A big thank you to all the following people who contributed to the 5.0 release!
+
+### [Milestone 6.0.8](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.8)
+
+| Contributor                      | Assigned issues                                                                                            |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji) | [3](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.8+is%3Aclosed+assignee%3Aroji) |
+
+### [Milestone 6.0.7](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.7)
+
+| Contributor                      | Assigned issues                                                                                            |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji) | [5](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.7+is%3Aclosed+assignee%3Aroji) |
+
+### [Milestone 6.0.6](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.6)
+
+| Contributor                      | Assigned issues                                                                                            |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji) | [2](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.6+is%3Aclosed+assignee%3Aroji) |
+
+### [Milestone 6.0.5](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.5)
+
+| Contributor                      | Assigned issues                                                                                            |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji) | [5](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.5+is%3Aclosed+assignee%3Aroji) |
+
+### [Milestone 6.0.4](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.4)
+
+| Contributor                              | Assigned issues                                                                                                |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji)         | [6](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.4+is%3Aclosed+assignee%3Aroji)     |
+| [@kourosko](https://github.com/kourosko) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.4+is%3Aclosed+assignee%3Akourosko) |
+
+### [Milestone 6.0.3](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.3)
+
+| Contributor                            | Assigned issues                                                                                               |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji)       | [8](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.3+is%3Aclosed+assignee%3Aroji)    |
+| [@rus-art](https://github.com/rus-art) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.3+is%3Aclosed+assignee%3Arus-art) |
+
+### [Milestone 6.0.2](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.2)
+
+| Contributor                      | Assigned issues                                                                                            |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji) | [4](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.2+is%3Aclosed+assignee%3Aroji) |
+
+### [Milestone 6.0.1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.1)
+
+| Contributor                              | Assigned issues                                                                                                |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji)         | [5](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.1+is%3Aclosed+assignee%3Aroji)     |
+| [@Brar](https://github.com/Brar)         | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.1+is%3Aclosed+assignee%3ABrar)     |
+| [@vonzshik](https://github.com/vonzshik) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.1+is%3Aclosed+assignee%3Avonzshik) |
+
+### [Milestone 6.0.0](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.0)
+
+| Contributor                                | Assigned issues                                                                                                 |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji)           | [56](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.0+is%3Aclosed+assignee%3Aroji)     |
+| [@vonzshik](https://github.com/vonzshik)   | [2](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.0+is%3Aclosed+assignee%3Avonzshik)  |
+| [@arontsang](https://github.com/arontsang) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.0+is%3Aclosed+assignee%3Aarontsang) |
+| [@Isitar](https://github.com/Isitar)       | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.0+is%3Aclosed+assignee%3AIsitar)    |
+| [@kislovs](https://github.com/kislovs)     | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.0+is%3Aclosed+assignee%3Akislovs)   |
+| [@pafrench](https://github.com/pafrench)   | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.0+is%3Aclosed+assignee%3Apafrench)  |
+| [@tiborfsk](https://github.com/tiborfsk)   | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A6.0.0+is%3Aclosed+assignee%3Atiborfsk)  |

--- a/conceptual/EFCore.PG/release-notes/7.0.md
+++ b/conceptual/EFCore.PG/release-notes/7.0.md
@@ -101,3 +101,39 @@ protected override void ConfigureConventions(ModelConfigurationBuilder configura
     configurationBuilder.Properties<string>().UseCollation("<collation_name>");
 }
 ```
+
+## Contributors
+
+A big thank you to all the following people who contributed to the 5.0 release!
+
+### [Milestone 7.0.11](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A7.0.11)
+
+| Contributor                      | Assigned issues                                                                                             |
+| -------------------------------- | -----------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A7.0.11+is%3Aclosed+assignee%3Aroji) |
+
+### [Milestone 7.0.4](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A7.0.4)
+
+| Contributor                      | Assigned issues                                                                                            |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji) | [7](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A7.0.4+is%3Aclosed+assignee%3Aroji) |
+
+### [Milestone 7.0.3](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A7.0.3)
+
+| Contributor                                      | Assigned issues                                                                                                    |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------:|
+| [@jhartmann123](https://github.com/jhartmann123) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A7.0.3+is%3Aclosed+assignee%3Ajhartmann123) |
+| [@roji](https://github.com/roji)                 | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A7.0.3+is%3Aclosed+assignee%3Aroji)         |
+
+### [Milestone 7.0.1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A7.0.1)
+
+| Contributor                      | Assigned issues                                                                                            |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji) | [3](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A7.0.1+is%3Aclosed+assignee%3Aroji) |
+
+### [Milestone 7.0.0](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A7.0.0)
+
+| Contributor                              | Assigned issues                                                                                                |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji)         | [35](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A7.0.0+is%3Aclosed+assignee%3Aroji)    |
+| [@midgleyc](https://github.com/midgleyc) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A7.0.0+is%3Aclosed+assignee%3Amidgleyc) |

--- a/conceptual/EFCore.PG/release-notes/8.0.md
+++ b/conceptual/EFCore.PG/release-notes/8.0.md
@@ -235,3 +235,14 @@ class MyConverter : ValueConverter<MyType, string>
 ### `cidr` now maps to `NpgsqlCidr` instead of `ValueTuple<IPAddress, int>`
 
 As part of improving Npgsql's support for the PostgreSQL network mappings, the PostgreSQL `cidr` type now maps to the newly-introduced <xref:NpgsqlTypes.NpgsqlCidr>, and can no longer be mapped to `ValueTuple<IPAddress, int>`.
+
+## Contributors
+
+A big thank you to all the following people who contributed to the 5.0 release!
+
+### [Milestone 8.0.0](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A8.0.0)
+
+| Contributor                        | Assigned issues                                                                                             |
+| ---------------------------------- | -----------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji)   | [34](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A8.0.0+is%3Aclosed+assignee%3Aroji) |
+| [@zpaks](https://github.com/zpaks) | [1](https://github.com/Npgsql/efcore.pg/issues?q=is%3Aissue+milestone%3A8.0.0+is%3Aclosed+assignee%3Azpaks) |

--- a/conceptual/Npgsql/release-notes/3.1.md
+++ b/conceptual/Npgsql/release-notes/3.1.md
@@ -22,6 +22,12 @@
 
 Thank you very much to the following people who have contributed to the individual 3.1.x. releases.
 
+### [Milestone 3.1.10](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A3.1.10)
+
+| Contributor                      | Assigned issues                                                                                          |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji) | [5](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A3.1.10+is%3Aclosed+assignee%3Aroji) |
+
 ### [Milestone 3.1.9](https://github.com/npgsql/npgsql/issues?q=is%3Aissue+milestone%3A3.1.9)
 
 Contributor                                  | Assigned issues

--- a/conceptual/Npgsql/release-notes/3.2.md
+++ b/conceptual/Npgsql/release-notes/3.2.md
@@ -25,15 +25,6 @@ Many other small changes have been made, especially with regards to performance.
 
 Thank you very much to the following people who have contributed to the individual 3.2.x. releases.
 
-### [Milestone 3.2.8](https://github.com/npgsql/npgsql/issues?q=is%3Aissue+milestone%3A3.2.8)
-
-Contributor                                            | Assigned issues
------------------------------------------------------- | ----------------:|
-[@roji](https://github.com/roji)                       | [4](https://github.com/npgsql/npgsql/issues?q=is%3Aissue+milestone%3A3.2.8+is%3Aclosed+assignee%3Aroji)
-[@Brar](https://github.com/Brar)                       | [2](https://github.com/npgsql/npgsql/issues?q=is%3Aissue+milestone%3A3.2.8+is%3Aclosed+assignee%3ABrar)
-[@ErikEJ](https://github.com/ErikEJ)                   | [1](https://github.com/npgsql/npgsql/issues?q=is%3Aissue+milestone%3A3.2.8+is%3Aclosed+assignee%3AErikEJ)
-[@YohDeadfall](https://github.com/YohDeadfall)         | [1](https://github.com/npgsql/npgsql/issues?q=is%3Aissue+milestone%3A3.2.8+is%3Aclosed+assignee%3AYohDeadfall)
-
 ### [Milestone 3.2.7](https://github.com/npgsql/npgsql/issues?q=is%3Aissue+milestone%3A3.2.7)
 
 Contributor                                            | Assigned issues

--- a/conceptual/Npgsql/release-notes/4.0.md
+++ b/conceptual/Npgsql/release-notes/4.0.md
@@ -86,6 +86,21 @@ In addition to more documentation, several blog posts are planned to explain the
 
 Thank you very much to the following people who have contributed to the individual 4.0.x. releases.
 
+### [Milestone 4.0.11](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A4.0.11)
+
+| Contributor                                    | Assigned issues                                                                                                 |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------:|
+| [@manandre](https://github.com/manandre)       | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A4.0.11+is%3Aclosed+assignee%3Amanandre)    |
+| [@roji](https://github.com/roji)               | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A4.0.11+is%3Aclosed+assignee%3Aroji)        |
+| [@YohDeadfall](https://github.com/YohDeadfall) | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A4.0.11+is%3Aclosed+assignee%3AYohDeadfall) |
+
+### [Milestone 4.0.10](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A4.0.10)
+
+| Contributor                        | Assigned issues                                                                                           |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------:|
+| [@kYann](https://github.com/kYann) | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A4.0.10+is%3Aclosed+assignee%3AkYann) |
+| [@roji](https://github.com/roji)   | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A4.0.10+is%3Aclosed+assignee%3Aroji)  |
+
 ### [Milestone 4.0.9](https://github.com/npgsql/npgsql/issues?q=is%3Aissue+milestone%3A4.0.9)
 
 Contributor                                     | Assigned issues

--- a/conceptual/Npgsql/release-notes/4.1.md
+++ b/conceptual/Npgsql/release-notes/4.1.md
@@ -25,6 +25,12 @@ Many other small improvements and performance optimizations have been introduced
 
 Thank you very much to the following people who have contributed to the individual 4.1.x. releases.
 
+### [Milestone 4.1.12](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A4.1.12)
+
+| Contributor                      | Assigned issues                                                                                          |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------:|
+| [@roji](https://github.com/roji) | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A4.1.12+is%3Aclosed+assignee%3Aroji) |
+
 ### [Milestone 4.1.9](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A4.1.9)
 
 | Contributor                                    | Assigned issues

--- a/conceptual/Npgsql/release-notes/7.0.md
+++ b/conceptual/Npgsql/release-notes/7.0.md
@@ -139,6 +139,28 @@ Previously, replication APIs returned `DateTime` instances of Kind `Unspecified`
 
 Thank you very much to the following people who have contributed to the individual 7.0.x. releases.
 
+### [Milestone 7.0.6](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A7.0.6)
+
+| Contributor                              | Assigned issues                                                                                              |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------:|
+| [@vonzshik](https://github.com/vonzshik) | [10](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A7.0.6+is%3Aclosed+assignee%3Avonzshik) |
+| [@roji](https://github.com/roji)         | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A7.0.6+is%3Aclosed+assignee%3Aroji)      |
+
+### [Milestone 7.0.4](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A7.0.4)
+
+| Contributor                              | Assigned issues                                                                                             |
+| ---------------------------------------- | -----------------------------------------------------------------------------------------------------------:|
+| [@vonzshik](https://github.com/vonzshik) | [3](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A7.0.4+is%3Aclosed+assignee%3Avonzshik) |
+| [@roji](https://github.com/roji)         | [2](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A7.0.4+is%3Aclosed+assignee%3Aroji)     |
+
+### [Milestone 7.0.2](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A7.0.2)
+
+| Contributor                              | Assigned issues                                                                                             |
+| ---------------------------------------- | -----------------------------------------------------------------------------------------------------------:|
+| [@vonzshik](https://github.com/vonzshik) | [5](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A7.0.2+is%3Aclosed+assignee%3Avonzshik) |
+| [@manandre](https://github.com/manandre) | [2](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A7.0.2+is%3Aclosed+assignee%3Amanandre) |
+| [@roji](https://github.com/roji)         | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A7.0.2+is%3Aclosed+assignee%3Aroji)     |
+
 ### [Milestone 7.0.1](https://github.com/npgsql/npgsql/issues?q=is%3Aissue+milestone%3A7.0.1)
 
 | Contributor                              | Assigned issues                                                                                             |

--- a/conceptual/Npgsql/release-notes/8.0.md
+++ b/conceptual/Npgsql/release-notes/8.0.md
@@ -126,3 +126,22 @@ As part of the effort to make Npgsql compatible with NativeAOT and trimming, the
 
 > [!WARNING]
 > If you're a plugin developer, be aware that some last API changes may still be done; it's advisable to wait until 8.0 is released before adapting your plugin. In any case, please reach out to us via Github issues if you encounter any issues or require guidance!
+
+## Contributors
+
+Thank you very much to the following people who have contributed to the individual 7.0.x. releases.
+
+### [Milestone 8.0.0](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A8.0.0)
+
+| Contributor                                                            | Assigned issues                                                                                                            |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------:|
+| [@NinoFloris](https://github.com/NinoFloris)                           | [43](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A8.0.0+is%3Aclosed+assignee%3ANinoFloris)             |
+| [@vonzshik](https://github.com/vonzshik)                               | [23](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A8.0.0+is%3Aclosed+assignee%3Avonzshik)               |
+| [@roji](https://github.com/roji)                                       | [20](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A8.0.0+is%3Aclosed+assignee%3Aroji)                   |
+| [@manandre](https://github.com/manandre)                               | [4](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A8.0.0+is%3Aclosed+assignee%3Amanandre)                |
+| [@BogdanYarotsky](https://github.com/BogdanYarotsky)                   | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A8.0.0+is%3Aclosed+assignee%3ABogdanYarotsky)          |
+| [@Brar](https://github.com/Brar)                                       | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A8.0.0+is%3Aclosed+assignee%3ABrar)                    |
+| [@erikdesj](https://github.com/erikdesj)                               | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A8.0.0+is%3Aclosed+assignee%3Aerikdesj)                |
+| [@SoftStoneDevelop](https://github.com/SoftStoneDevelop)               | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A8.0.0+is%3Aclosed+assignee%3ASoftStoneDevelop)        |
+| [@sonquer](https://github.com/sonquer)                                 | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A8.0.0+is%3Aclosed+assignee%3Asonquer)                 |
+| [@yucelkivanc-hepsiburada](https://github.com/yucelkivanc-hepsiburada) | [1](https://github.com/Npgsql/Npgsql/issues?q=is%3Aissue+milestone%3A8.0.0+is%3Aclosed+assignee%3Ayucelkivanc-hepsiburada) |


### PR DESCRIPTION
Patch contributions without an assigned issue are still missing. This will follow in a separate PR after updating the generator program at some point.