### PR TITLE
Add warning for data source gotcha in NetTopologySuite docs

### DIFF
--- a/conceptual/EFCore.PG/mapping/nts.md
+++ b/conceptual/EFCore.PG/mapping/nts.md
@@ -13,6 +13,9 @@ To use the NetTopologySuite plugin, add the [Npgsql.EntityFrameworkCore.PostgreS
 
 ### [NpgsqlDataSource](#tab/with-datasource)
 
+> [!WARNING]
+> Ensure you build your data source `dataSourceBuilder.Build();` _outside_ of the `AddDbContext()`` configure callback otherwise a new ServiceProvider will be created for each DbContext instance
+
 Since version 7.0, NpgsqlDataSource is the recommended way to use Npgsql. When using NpsgqlDataSource, NetTopologySuite currently has to be configured twice - once at the EF level, and once at the underlying ADO.NET level (there are plans to improve this):
 
 ```c#


### PR DESCRIPTION
We got hung up on this one for quite a while, it's an easy gotcha to run into if you are setting up `NetTopologySuite` in an existing application that obtains the connection string via DI inside of the configuring callback of `AddDbContext`.

Setting up the data source inside of the `OnConfiguring` callback causes the dependencies of the `DbContextOptions` to be different every time, causing a new `ServiceProvider` to be made for each `DbContext` which will eventually warn/error with the `LogManyServiceProvidersCreated` error in EF Core.

Please advise preferred verbiage and location.