### PR TITLE
Update nts.md by changing EF version from 9 to 8

### DIFF
--- a/conceptual/EFCore.PG/mapping/nts.md
+++ b/conceptual/EFCore.PG/mapping/nts.md
@@ -11,7 +11,7 @@ Note that the EF Core NetTopologySuite plugin depends on [the Npgsql ADO.NET Net
 
 To use the NetTopologySuite plugin, add the [Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite nuget](https://www.nuget.org/packages/Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite) to your project. Then, configure the NetTopologySuite plugin as follows:
 
-### [EF 9.0, with a connection string](#tab/ef9-with-connection-string)
+### [EF 8.0, with a connection string](#tab/ef8-with-connection-string)
 
 If you're passing a connection string to `UseNpgsql`, simply add the `UseNetTopologySuite` call as follows:
 


### PR DESCRIPTION
We are using .NET 8 and Entity Framework Core 8. Directly passing a connecting string for Postgis with Npgsql worked with our current EF version:
`builder.Services.AddDbContext<MyContext>(options => options.UseNpgsql(
    "<connection string>",
    o => o.UseNetTopologySuite()));`

So I propose to change the version of EF mentioned in the docs from 9 to 8.