### PR TITLE
Map property to column xmin

### DIFF
--- a/conceptual/EFCore.PG/modeling/concurrency.md
+++ b/conceptual/EFCore.PG/modeling/concurrency.md
@@ -18,7 +18,7 @@ public class SomeEntity
 {
     public int Id { get; set; }
 
-    [Timestamp]
+    [Column("xmin")]
     public uint Version { get; set; }
 }
 ```
@@ -34,7 +34,8 @@ class MyContext : DbContext
     {
         modelBuilder.Entity<SomeEntity>()
             .Property(b => b.Version)
-            .IsRowVersion();
+            .IsRowVersion()
+            .HasColumnName("xmin");
     }
 }
 


### PR DESCRIPTION
The column "xmin" is a default hidden column for every table in PostgreSQL. In order to use the concurrency feature, the best is to map a property to this auto-updating column. If it is just done as described in the docs now, with a random column name mapped to type 'xid', the column value remains at its default 0 on insert and upate.