### PR TITLE
Update connection-string-parameters.md

### DIFF
--- a/conceptual/Npgsql/connection-string-parameters.md
+++ b/conceptual/Npgsql/connection-string-parameters.md
@@ -43,7 +43,7 @@ Minimum Pool Size           | The minimum connection pool size.          | 0
 Maximum Pool Size           | The maximum connection pool size.          | 100 since 3.1, 20 previously
 Connection Idle Lifetime    | The time (in seconds) to wait before closing idle connections in the pool if the count of all connections exceeds `Minimum Pool Size`. Introduced in 3.1. | 300
 Connection Pruning Interval | How many seconds the pool waits before attempting to prune idle connections that are beyond idle lifetime (see `Connection Idle Lifetime`). Introduced in 3.1. | 10
-Connection Lifetime         | The total maximum lifetime of connections (in seconds). Connections which have exceeded this value will be destroyed instead of returned from the pool. This is useful in clustered configurations to force load balancing between a running server and a server just brought online. | 3600 (1 hour), in Npgsql 8.0 and before - 0 (disabled)
+Connection Lifetime         | The total maximum lifetime of connections (in seconds). Connections which have exceeded this value will be destroyed instead of returned from the pool. This is useful in clustered configurations to force load balancing between a running server and a server just brought online. | 3600 (1 hour) since 9.0, 0 (disabled) previously
 
 ## Timeouts and keepalive
 


### PR DESCRIPTION
I thought this read as 1 hour in Npgsql 8.0 and before, and now disabled. Turns out I had that flipped. I changed the wording to match that of how "Maximum Pool Size" was worded. Which I think is clearer.