### PR TITLE
Added large-objects.md to toc.yml

### DIFF
--- a/conceptual/Npgsql/toc.yml
+++ b/conceptual/Npgsql/toc.yml
@@ -74,6 +74,8 @@
     href: failover-and-load-balancing.md
   - name: Bulk copy
     href: copy.md
+  - name: Large objects
+    href: large-objects.md
   - name: Waiting for notifications
     href: wait.md
   - name: Keepalive


### PR DESCRIPTION
Large-objects.md was not in toc.yml and hence seemed to be missing from the documentation.